### PR TITLE
Fix, refactor and add functions

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,10 @@
 # and commit this file to your remote git repository to share the goodness with others.
 
 tasks:
-  - init: cargo build
+  - init: |
+      cargo check
+      cargo clippy
+      cargo build
 vscode:
   extensions:
     - "Zerotaskx.rust-extension-pack"

--- a/crates/fefast/src/codec.rs
+++ b/crates/fefast/src/codec.rs
@@ -235,9 +235,17 @@ pub fn decode_stop_bit_bitvec(input: &mut impl io::Read) -> io::Result<BitVec> {
         input.read_exact(&mut buffer[..])?;
         let byte = buffer[0];
         stop_bit = byte >= STOP_BYTE;
+
         if !stop_bit {
+            // We will push 9 elements.
+            bits.reserve(9);
             bits.push(byte >> 7 == 1);
+        } else {
+            // We will push only 8 elements
+            // (no need to push byte >> 7 == 1).
+            bits.reserve(8);
         }
+
         bits.push((byte >> 6) & 1 == 1);
         bits.push((byte >> 5) & 1 == 1);
         bits.push((byte >> 4) & 1 == 1);
@@ -245,7 +253,7 @@ pub fn decode_stop_bit_bitvec(input: &mut impl io::Read) -> io::Result<BitVec> {
         bits.push((byte >> 3) & 1 == 1);
         bits.push((byte >> 2) & 1 == 1);
         bits.push((byte >> 1) & 1 == 1);
-        bits.push((byte >> 0) & 1 == 1);
+        bits.push(byte & 1 == 1);
     }
     Ok(bits)
 }

--- a/crates/fefast/src/decimal.rs
+++ b/crates/fefast/src/decimal.rs
@@ -426,7 +426,7 @@ impl fmt::Display for Decimal {
         if self.fract().is_positive() {
             // We just verified we have some decimal digits, so we're gonna need
             // the decimal point.
-            write!(f, ".{}", "")?;
+            f.write_str(".")?;
             // Here we take the mantissa of the fractional part.
             let digits = self.fract().mantissa().to_string();
             let digits_len = digits.chars().count();

--- a/crates/fefast/src/decimal.rs
+++ b/crates/fefast/src/decimal.rs
@@ -327,6 +327,10 @@ impl Decimal {
     /// let num = Decimal::new(11, -1);
     /// assert_eq!(num.pow(2), Decimal::new(121, -2));
     /// ```
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if `exp` is negative.
     pub fn pow(&self, exp: i32) -> Self {
         match exp.signum() {
             0 => Self::ONE,

--- a/crates/fefix/src/fefix_core/dict.rs
+++ b/crates/fefix/src/fefix_core/dict.rs
@@ -102,12 +102,12 @@ impl fmt::Display for Dictionary {
         {
             writeln!(f, " <messages>")?;
             for message in self.iter_messages() {
+                // FIXME: msgcat's value
                 writeln!(
                     f,
-                    "  <message name='{}' msgtype='{}' msgcat='{}'>",
+                    "  <message name='{}' msgtype='{}' msgcat='TODO'>",
                     message.name(),
                     message.msg_type(),
-                    "TODO"
                 )?;
                 for item in message.layout() {
                     display_layout_item(2, item, f)?;

--- a/crates/fefix/src/tagvalue/encoder.rs
+++ b/crates/fefix/src/tagvalue/encoder.rs
@@ -221,8 +221,7 @@ where
     where
         T: FixValue<'b>,
     {
-        todo!()
-        // self.set_fv(key, value);
+        self.set_with(*key, value, T::SerializeSettings::default());
     }
 
     fn set_fv<'b, V, F>(&'b mut self, field: &F, value: V)

--- a/crates/fefixs/src/lib.rs
+++ b/crates/fefixs/src/lib.rs
@@ -163,17 +163,17 @@ const V1_DRAFT_RECOMMENDED_CIPHERSUITES_PSK_ONLY: &[&str] = &[
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
     #[test]
     #[cfg(feature = "utils-openssl")]
     fn v1draft_acceptor_is_ok() {
+        use super::Version;
         Version::V1Draft.recommended_acceptor_builder();
     }
 
     #[test]
     #[cfg(feature = "utils-openssl")]
     fn v1draft_connector_is_ok() {
+        use super::Version;
         Version::V1Draft.recommended_connector_builder();
     }
 }

--- a/crates/fesofh/src/lib.rs
+++ b/crates/fesofh/src/lib.rs
@@ -63,7 +63,7 @@ pub enum Error {
         needed: usize,
     },
     /// I/O-related error.
-    #[error("I/O related error.")]
+    #[error("I/O error: {0}")]
     Io(#[from] io::Error),
 }
 

--- a/crates/fesofh/src/lib.rs
+++ b/crates/fesofh/src/lib.rs
@@ -67,6 +67,8 @@ pub enum Error {
     Io(#[from] io::Error),
 }
 
+pub type FesofhResult<T> = Result<T, Error>;
+
 /// The header of a SOFH-enclosed message.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct Header {


### PR DESCRIPTION
## Features

- feat(gitpod): run cargo check & clippy
- feat(fesofh): add FesofhResult
- feat(fesofh): append io:Error details to message
- feat(fefix/tagvalue): implement set_fv_with_key

## Fixes
- fix(fefix/core): move "TODO" to msgcat
- fix(fefixs/test): move super::* to test children

## Performance Improvement

- perf(fefast/codec): porting the above optimization
- perf(fefast/decimal): no meaningless format

## Documents

- docs(fefast/decimal): add pow()'s “Panics“ section

## Refactor

- refactor!(fesofh/seq_decoder): avoid `panic!()`
